### PR TITLE
Preserve working LSM IC-only cases

### DIFF
--- a/scm/src/scm_type_defs.F90
+++ b/scm/src/scm_type_defs.F90
@@ -1064,7 +1064,7 @@ module scm_type_defs
       !
       ! Orographical data (2D)
       !
-      if (scm_state%model_ics .or. scm_state%lsm_ics) then
+      if (scm_state%model_ics) then
         write(0,'(a)') "Setting internal physics variables from the orographic section of the case input file (scalars)..."
         call conditionally_set_var(scm_input%input_stddev,    physics%Sfcprop%hprime(i,1),  "stddev",    .true., missing_var(1))
         call conditionally_set_var(scm_input%input_convexity, physics%Sfcprop%hprime(i,2),  "convexity", .true., missing_var(2))
@@ -1082,10 +1082,7 @@ module scm_type_defs
         call conditionally_set_var(scm_input%input_elvmax,    physics%Sfcprop%hprime(i,14), "elvmax",    .true., missing_var(14))
         call conditionally_set_var(scm_input%input_oro,       physics%Sfcprop%oro(i),       "oro",       .true., missing_var(15))
         call conditionally_set_var(scm_input%input_oro_uf,    physics%Sfcprop%oro_uf(i),    "oro_uf",    (physics%Model%do_ugwp .and. physics%Model%nmtvr == 14), missing_var(16))
-        call conditionally_set_var(scm_input%input_landfrac,  physics%Sfcprop%landfrac(i),  "landfrac",  physics%Model%frac_grid, missing_var(17))
-        call conditionally_set_var(scm_input%input_lakefrac,  physics%Sfcprop%lakefrac(i),  "lakefrac",  (physics%Model%lkm == 1), missing_var(18))
-        call conditionally_set_var(scm_input%input_lakedepth, physics%Sfcprop%lakedepth(i), "lakedepth", (physics%Model%lkm == 1), missing_var(19))
-        
+                
         n = 19
         if ( i==1 .and. ANY( missing_var(1:n) ) ) then
           write(0,'(a)') "INPUT CHECK: Some missing input data was found related to (potentially non-required) orography and gravity wave drag parameters. This may lead to crashes or other strange behavior."
@@ -1096,6 +1093,20 @@ module scm_type_defs
         end if
         missing_var = .false.
       end if
+      
+      ! Variables found in orographic dataset but needed for non-orographic reasons (e.g. lake model, fractional grid)
+      call conditionally_set_var(scm_input%input_landfrac,  physics%Sfcprop%landfrac(i),  "landfrac",  physics%Model%frac_grid, missing_var(1))
+      call conditionally_set_var(scm_input%input_lakefrac,  physics%Sfcprop%lakefrac(i),  "lakefrac",  (physics%Model%lkm == 1), missing_var(2))
+      call conditionally_set_var(scm_input%input_lakedepth, physics%Sfcprop%lakedepth(i), "lakedepth", (physics%Model%lkm == 1), missing_var(3))
+      n = 3
+      if ( i==1 .and. ANY( missing_var(1:n) ) ) then
+        write(0,'(a)') "INPUT CHECK: Some missing input data was found related to (potentially non-required) lake-related or fractional grid-related variables. This may lead to crashes or other strange behavior."
+        write(0,'(a)') "Check scm_type_defs.F90/physics_set to see the names of variables that are missing, corresponding to the following indices:"
+        do j=1, n
+          if (missing_var(j)) write(0,'(a,i0)') "variable index ",j
+        end do
+      end if
+      missing_var = .false.
       
       !
       ! Surface data (2D)


### PR DESCRIPTION
For cases that specify `lsm_ics=T`, but not `model_ics=T` (like GABLS3), we can't add the requirement that orographic variables be present. By moving the statements involving `lakefrac`,`landfrac`, and `lakedepth` out of the broader IF statement and putting them where they are required and set only when their specific conditions are met (frac_grid is set or lkm==1) , this preserves this funcitonality.

Please test this change with your lake case to make sure that it still works too.